### PR TITLE
fix rate limit errors

### DIFF
--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -82,7 +82,9 @@ def people_worksheet_range
 end
 
 def worksheet(spreadsheet_key=SPREADSHEET_KEY, range, value_render_option: nil)
-  google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
+    google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
+  rescue Google::Apis::RateLimitError error
+    puts error.inspect
 end
 
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -83,7 +83,7 @@ end
 
 def worksheet(spreadsheet_key=SPREADSHEET_KEY, range, value_render_option: nil)
     google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
-  rescue Error error
+  rescue => error
     puts error.inspect
 end
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -49,8 +49,11 @@ def title spreadsheet_key
     begin
       sheet = google_sheets.get_spreadsheet(spreadsheet_key).properties.title
     rescue => error
+      puts "title rate limit exceeded"
       puts error.inspect
-      sleep(2 ** n)
+      wait_time = (2 ** n)
+      puts "wait time: #{wait_time}"
+      sleep(wait_time)
       next
     end
   end
@@ -94,11 +97,15 @@ def worksheet(spreadsheet_key=SPREADSHEET_KEY, range, value_render_option: nil)
     begin
       return google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
     rescue => error
+      puts "worksheet rate limit exceeded"
       puts error.inspect
-      sleep(2 ** n)
+      wait_time = (2 ** n)
+      puts "wait time: #{wait_time}"
+      sleep(wait_time)
       next
     end
   end
+  fail "max number of retries for rate limit exceeded"
 end
 
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -45,9 +45,15 @@ def store_individual_balances_and_creditors
 end
 
 def title spreadsheet_key
-    sheet = google_sheets.get_spreadsheet(spreadsheet_key).properties.title
-  rescue => error
-    puts error.inspect
+  (0..5).each do |n|
+    begin
+      sheet = google_sheets.get_spreadsheet(spreadsheet_key).properties.title
+    rescue => error
+      puts error.inspect
+      sleep(2 ** n)
+      next
+    end
+  end
 end
 
 def store_user_profile
@@ -84,9 +90,15 @@ def people_worksheet_range
 end
 
 def worksheet(spreadsheet_key=SPREADSHEET_KEY, range, value_render_option: nil)
-    google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
-  rescue => error
-    puts error.inspect
+  (0..5).each do |n|
+    begin
+      return google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
+    rescue => error
+      puts error.inspect
+      sleep(2 ** n)
+      next
+    end
+  end
 end
 
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -45,7 +45,9 @@ def store_individual_balances_and_creditors
 end
 
 def title spreadsheet_key
-  sheet = google_sheets.get_spreadsheet(spreadsheet_key).properties.title
+    sheet = google_sheets.get_spreadsheet(spreadsheet_key).properties.title
+  rescue => error
+    puts error.inspect
 end
 
 def store_user_profile

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -83,7 +83,7 @@ end
 
 def worksheet(spreadsheet_key=SPREADSHEET_KEY, range, value_render_option: nil)
     google_sheets.get_spreadsheet_values(spreadsheet_key, range, value_render_option: value_render_option).values
-  rescue Google::Apis::RateLimitError error
+  rescue Error error
     puts error.inspect
 end
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -93,7 +93,7 @@ end
 def google_sheets
   Google::Apis::SheetsV4::SheetsService.new.tap do |service|
     service.authorization = decoded_google_authorization_from_env
-    quota_user = "hot_custard_payments_user"
+    quota_user = "hot_custard_payments_user_#{rand(100000)}"
   end
 end
 

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -108,5 +108,5 @@ flush_datastore
 DATASTORE.pipelined do
   store_user_profile
   store_transactions
-  store_individual_balances_and_creditors
+  # store_individual_balances_and_creditors
 end

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -27,6 +27,7 @@ def balances
   Hash.new({}).tap do |balances|
     spreadsheet_keys.each do |key|
       people = worksheet(key, "PeopleWithCosts")[0]
+      sleep 1
       amounts = worksheet(key, "IndividualAmounts")[0]
       title = title(key)
       people.each_with_index do |person, index|

--- a/populate_datastore.rb
+++ b/populate_datastore.rb
@@ -27,7 +27,6 @@ def balances
   Hash.new({}).tap do |balances|
     spreadsheet_keys.each do |key|
       people = worksheet(key, "PeopleWithCosts")[0]
-      sleep 1
       amounts = worksheet(key, "IndividualAmounts")[0]
       title = title(key)
       people.each_with_index do |person, index|
@@ -94,6 +93,7 @@ end
 def google_sheets
   Google::Apis::SheetsV4::SheetsService.new.tap do |service|
     service.authorization = decoded_google_authorization_from_env
+    quota_user = "hot_custard_payments_user"
   end
 end
 
@@ -108,5 +108,5 @@ flush_datastore
 DATASTORE.pipelined do
   store_user_profile
   store_transactions
-  # store_individual_balances_and_creditors
+  store_individual_balances_and_creditors
 end


### PR DESCRIPTION
The errors are occurring on CircleCI, e.g. "rateLimitExceeded: Insufficient tokens for quota group and limit 'ReadGroupUSER-100s' of service 'sheets.googleapis.com', using the limit by ID '<redacted>'. (Google::Apis::RateLimitError)"

Could use a [batch get](https://developers.google.com/sheets/reference/rest/v4/spreadsheets.values/batchGet) to retrieve multiple ranges from the same spreadsheet in one request.
This may not fix it though - but worth a try in the first instance.
