### PR TITLE
Fix RubyMoney localization deprecation warning

### DIFF
--- a/hcmoney.rb
+++ b/hcmoney.rb
@@ -7,6 +7,7 @@ I18n.enforce_available_locales = false
 
 # Hot Custard tailored implementation of money
 class HCMoney
+  Money.locale_backend = :i18n
   Money.default_bank = MoneyOXR::Bank.new(
     app_id: ENV['OPEN_EXCHANGE_RATES_APP_ID'],
     cache_path: '/tmp/oxr.json',


### PR DESCRIPTION
"You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation"