### PR TITLE
Populate datastore on deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec ruby populate_datastore.rb
 web: bundle exec rackup config.ru -s puma -p $PORT


### PR DESCRIPTION
Prior to this change, the datastore was not being updated when doing an automated deployment.