### PR TITLE
Check commit messages for style

### DIFF
--- a/.github/workflows/check_commit_message.yml
+++ b/.github/workflows/check_commit_message.yml
@@ -1,0 +1,23 @@
+---
+name: 'Check commit message style'
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  check-commit-message-style:
+    if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/github_actions/') == false)
+    name: Check commit message style
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2.1.2
+        with:
+          allow-one-liners: 'true'


### PR DESCRIPTION
The checks are based on the style [suggested by Chris Beams][1].
They use a [GitHub Action][2] by [mristin][3], which runs on every
push and pull request.

[1]: https://chris.beams.io/posts/git-commit/
[2]: https://github.com/features/actions
[3]: https://github.com/mristin/opinionated-commit-message