### PR TITLE
Fix commit check exclusion of master branch

### DIFF
--- a/.github/workflows/check_commit_message.yml
+++ b/.github/workflows/check_commit_message.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
   push:
     branches-ignore:
-      - main
+      - master
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
It was erroneously excluding `main` (which we don't have) rather than
`master`.