### PR TITLE
Use Zsh as the default terminal in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
+		"terminal.integrated.shell.linux": "/bin/zsh",
 		"ruby.useBundler": true, //run non-lint commands with bundle exec
 		"ruby.useLanguageServer": true, // use the internal language server (see below)
 		"ruby.lint": {


### PR DESCRIPTION
[Zsh is the default shell on MacOS from Catalina onwards][1], so it
makes sense to use it as the default on VS Code too.

[1]: https://support.apple.com/en-us/HT208050