### PR TITLE
Fix Redis gem version problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'money-oxr'
 gem 'omniauth-facebook'
 gem 'puma'
 # An error occurs when using Redis version 4 - not sure why, so staying with 3 for now at least
-gem 'redis', '>=3.3.3', '<4.0.0'
+gem 'redis', '~> 3.3'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'tilt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES
   money-oxr
   omniauth-facebook
   puma
-  redis (>= 3.3.3, < 4.0.0)
+  redis (~> 3.3)
   rspec
   rspec_junit_formatter
   sinatra


### PR DESCRIPTION
Prior to this commit we were using the verbose pessimistic constraint
version specifier for the Redis gem (documented [here][1], along with
the shorthand version).  Dependabot was not picking
up the pessimistic constraint and was [wrongly creating a PR to bump us
to the Redis 4.x gem][2], which we don't want to happen.

Fixed by using the [`~>` pessimistic constraint shortcut][3].

[1]: https://guides.rubygems.org/patterns/#pessimistic-version-constraint
[2]: https://github.com/johnboyes/hotcustard-payments/pull/112
[3]: https://thoughtbot.com/blog/rubys-pessimistic-operator