### PR TITLE
Add yaml VS Code extension to remote container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rebornix.Ruby",
-		"exiasr.hadolint"
+		"exiasr.hadolint",
+		"redhat.vscode-yaml"
 	],
 
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.


### PR DESCRIPTION
Using the [Red Hat YAML extension][1]

[1]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml