### PR TITLE
Use Dependabot to update indirect dependencies too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@
 
 version: 2
 updates:
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,10 +13,14 @@ updates:
     reviewers:
       - "johnboyes"
     rebase-strategy: "disabled"
+
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      # Allow both direct and indirect dependency updates
+      - dependency-type: "all"
     reviewers:
       - "johnboyes"
     rebase-strategy: "disabled"


### PR DESCRIPTION
If the frequency of the updates becomes painful we can look at reducing
the frequency later - keeping them as daily for now.

[Documentation on configuring dependabot updates][1]

[1]: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#allow