### PR TITLE
Fix build by bumping timeout to 30m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - checkout
       - run:
           name: Deploy Master to Heroku
+          no_output_timeout: 30m
           command: |
             git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
 


### PR DESCRIPTION
The CircleCI deploy build was commonly failing because the [no output
timeout][1] was being reached.  This fix bumps up the timeout from the
default 10 minutes to 30 minutes.

[1]: https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-