### PR TITLE
Minimise lengthy dependency update builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
     reviewers:
       - "johnboyes"
     rebase-strategy: "disabled"
@@ -18,6 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
     allow:
       # Allow both direct and indirect dependency updates
       - dependency-type: "all"

--- a/.github/workflows/check_commit_message.yml
+++ b/.github/workflows/check_commit_message.yml
@@ -21,4 +21,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'suppress, notify'
+          additional-verbs: 'suppress, notify, minimise'


### PR DESCRIPTION
Limit the [number of open dependency update
pull requests][1] of each type to 1.  This means
that we avoid having many pull requests all which
need to be rebased and rebuilt before merging.

[1]: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit