### PR TITLE
Fix bug with creditors page

### DIFF
--- a/hot_custard_payments.rb
+++ b/hot_custard_payments.rb
@@ -99,9 +99,9 @@ class HotCustardApp < Sinatra::Base
   def credits_for(creditor)
     creditor_balances =  balances_for(creditor).select { |_item, amount| amount.in_credit? }
     hot_custard_balances = balances_for('Hot Custard')
-    ary.to_h(creditor_balances.keys.map do |item|
+    (creditor_balances.keys.map do |item|
       [item, creditor_item_amounts(creditor_balances[item], (- hot_custard_balances[item]))]
-    end)
+    end).to_h
   end
 
   get '/payments' do
@@ -113,7 +113,7 @@ class HotCustardApp < Sinatra::Base
   end
 
   get '/payments/creditors', role: :financial_admin do
-    @creditors = ary.to_h(creditors.map { |creditor| [creditor, credits_for(creditor)] })
+    @creditors = (creditors.map { |creditor| [creditor, credits_for(creditor)] }).to_h
     erb :creditors
   end
 

--- a/spec/full_journey_spec.rb
+++ b/spec/full_journey_spec.rb
@@ -155,15 +155,15 @@ feature 'Full journey tests' do
     expect(page.status_code).to be 403
   end
 
-  # scenario 'financial admins can see what anyone who is owed money can be paid back' do
-  #   login FINANCIAL_ADMIN_FACEBOOK_NAME
-  #   visit '/'
-  #   click_on 'Creditors'
-  #   expect(page.current_path).to eq '/payments/creditors'
-  #   expect(page.status_code).to be 200
-  #   expect(page).to have_content "HC money that can be paid to #{CREDITOR_NAME}"
-  #   expect_all_amounts_to_be_monetary
-  # end
+  scenario 'financial admins can see what anyone who is owed money can be paid back' do
+    login FINANCIAL_ADMIN_FACEBOOK_NAME
+    visit '/'
+    click_on 'Creditors'
+    expect(page.current_path).to eq '/payments/creditors'
+    expect(page.status_code).to be 200
+    expect(page).to have_content "HC money that can be paid to #{CREDITOR_NAME}"
+    expect_all_amounts_to_be_monetary
+  end
 
   scenario 'regular users cannot see what anyone who is owed money can be paid back' do
     login REGULAR_USER_FACEBOOK_NAME


### PR DESCRIPTION
The bug was introduced in 761b078a2f3e46995bf82f0027f4e70290b0df46,
when a poor attempt at a Rubocop "fix" led to mistakenly putting an
invalid method in.
    
Fixes #262