### PR TITLE
Change dependency update checks to be monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 1
     reviewers:
       - "johnboyes"
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 1
     allow:
       # Allow both direct and indirect dependency updates


### PR DESCRIPTION
Prior to this commit the dependency update checks from Dependabot were
daily.  Monthly is better, as we are not making many changes to this
codebase currently, and also because the CI tests take a while to run.