### PR TITLE
Stop Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,28 @@
 # rate limit per 100 seconds
 # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#rebase-strategy
 
-version: 2
-updates:
+# Commented out Dependabot updates in January 2023, as this repo is no longer actively maintained
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "johnboyes"
-    rebase-strategy: "disabled"
+# version: 2
+# updates:
 
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 1
-    allow:
-      # Allow both direct and indirect dependency updates
-      - dependency-type: "all"
-    reviewers:
-      - "johnboyes"
-    rebase-strategy: "disabled"
+#   - package-ecosystem: "github-actions"
+#     directory: "/"
+#     schedule:
+#       interval: "monthly"
+#     open-pull-requests-limit: 1
+#     reviewers:
+#       - "johnboyes"
+#     rebase-strategy: "disabled"
+
+#   - package-ecosystem: "bundler"
+#     directory: "/"
+#     schedule:
+#       interval: "monthly"
+#     open-pull-requests-limit: 1
+#     allow:
+#       # Allow both direct and indirect dependency updates
+#       - dependency-type: "all"
+#     reviewers:
+#       - "johnboyes"
+#     rebase-strategy: "disabled"


### PR DESCRIPTION
As this repo is longer actively maintained. If it is ever maintained in the future (unlikely, but you never know) then we will reactivate the Dependabot updates then.